### PR TITLE
Fix: luvit-meta/library not found using native package system

### DIFF
--- a/lua/lazydev/pkg.lua
+++ b/lua/lazydev/pkg.lua
@@ -33,9 +33,9 @@ function M.pack_unloaded()
   local Util = require("lazydev.util")
   packs = {} ---@type string[]
   for _, site in pairs(sites) do
-    for _, pack in ipairs(vim.fn.expand(site .. "/pack/*/opt/*/lua", false, true)) do
+    for _, pack in ipairs(vim.fn.expand(site .. "/pack/*/opt/*", false, true)) do
       if not pack:find("*", 1, true) then
-        packs[#packs + 1] = Util.norm(pack:sub(1, -5))
+        packs[#packs + 1] = Util.norm(pack)
       end
     end
   end


### PR DESCRIPTION
Using mini.deps, library luvit-meta is not found, when the plugin is not loaded.

In pkg.lua, function pack_unloaded, only plugins having a lua dir are returned.

Alternatives for this fix:
1. I can "add" the plugin.
2. Or, I could specify the full path in the setup of lazydev

I can imagine that when users have a lot of non-lua plugins, this fix will cause the for loop in method pack_unloaded to do more work. However, the same might hold for lazy.nvim internally.