### PR TITLE
feat: optionally add a completion source for coq_nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ workspace libraries.
 - will update your workspace libraries for:
   - **require** statements: `require("nvim-treesitter")`
   - **module annotations**: `---@module "nvim-treesitter"`
-- [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) completion source for the above
+- [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) and [nvim_coq](https://github.com/ms-jpq/coq_nvim) completion source for the above
 
 ![2024-06-01_21-02-40](https://github.com/folke/lazydev.nvim/assets/292349/c5f23225-88eb-454d-9b4e-1bf9183f7ff8)
 
@@ -26,7 +26,7 @@ workspace libraries.
   will only return loaded modules in your workspace.
 - To get around the above, you can:
   - pre-load those plugins with the `library` option.
-  - use the **nvim-cmp** completion source to get all available modules.
+  - use the **nvim-cmp** or **coq_nvim** completion source to get all available modules.
 - Neovim types are **NOT** included and also no longer needed
   on **Neovim >= 0.10**
 

--- a/lua/lazydev/config.lua
+++ b/lua/lazydev/config.lua
@@ -87,6 +87,7 @@ function M.setup(opts)
   vim.schedule(function()
     require("lazydev.buf").setup()
     require("lazydev.cmp").setup()
+    require("lazydev.coq").setup()
   end)
   return options
 end

--- a/lua/lazydev/coq.lua
+++ b/lua/lazydev/coq.lua
@@ -1,0 +1,81 @@
+local Buf = require("lazydev.buf")
+local Config = require("lazydev.config")
+local Pkg = require("lazydev.pkg")
+
+---@param map table<integer, table>
+local function new_uid(map)
+  local key ---@type integer|nil
+  while true do
+    if not key or map[key] then
+      key = math.floor(math.random() * 10000)
+    else
+      return key
+    end
+  end
+end
+
+---@param args {pos: {[1]: integer, [2]: integer}, line: string} (row, col)
+---@param callback fun(items: lsp.CompletionItem[])
+local function complete(args, callback)
+  if not Buf.attached[vim.api.nvim_get_current_buf()] then
+    return callback({})
+  end
+
+  local req, forward_slash = Pkg.get_module(args.line)
+  if not req then
+    return callback({})
+  end
+
+  local items = {} ---@type table<string,lsp.CompletionItem>
+
+  ---@param modname string
+  ---@param modpath string
+  local function add(modname, modpath)
+    items[modname] = items[modname]
+      or {
+        label = forward_slash and modname:gsub("%.", "/") or modname,
+        kind = vim.lsp.protocol.CompletionItemKind.Module,
+      }
+    local item = items[modname]
+
+    local plugin = Pkg.get_plugin_name(modpath)
+    if plugin then
+      if item.documentation then
+        item.documentation.value = item.documentation.value .. "\n- `" .. plugin .. "`"
+      else
+        item.documentation = {
+          kind = vim.lsp.protocol.MarkupKind.Markdown,
+          value = "# Plugins:\n" .. "- `" .. plugin .. "`",
+        }
+      end
+    end
+  end
+
+  if not req:find(".", 1, true) then
+    Pkg.topmods(add)
+    for _, lib in ipairs(Config.libs) do
+      for _, mod in ipairs(lib.mods) do
+        add(mod, lib.path)
+      end
+    end
+  else
+    Pkg.lsmod(req:gsub("%.[^%.]*$", ""), add)
+  end
+
+  callback(vim.tbl_values(items))
+end
+
+local M = {}
+
+function M.setup()
+  local ok = pcall(require, "coq")
+  if ok then
+    COQsources = COQsources or {} ---@type table<integer, table>
+    COQsources[new_uid(COQsources)] = {
+      name = "lazy",
+      fn = complete,
+    }
+  end
+end
+
+return M


### PR DESCRIPTION
I didn't saw the `cmp` option been used to conditionally enable the cmp completion source, so I didn't include a `coq_nvim` equivalent option. Should I add this to the PR?