### PR TITLE
docs: hint how to deal with .luarc.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ workspace libraries.
   - use the **nvim-cmp** or **coq_nvim** completion source to get all available modules.
 - Neovim types are **NOT** included and also no longer needed
   on **Neovim >= 0.10**
+- `.luarc.json` may break the plugin. If this is the case one can instruct git
+  to ignore local changes to this file and remove it.
+
+```sh
+git update-index --assume-unchanged .luarc.json
+rm .luarc.json
+```
 
 ## ⚡️ Requirements
 

--- a/doc/lazydev.nvim.txt
+++ b/doc/lazydev.nvim.txt
@@ -44,6 +44,11 @@ LIMITATIONS                            *lazydev.nvim-lazydev.nvim-limitations*
     - use the **nvim-cmp** or **coq_nvim** completion source to get all available modules.
 - Neovim types are **NOT** included and also no longer needed
     on **Neovim >= 0.10**
+- `.luarc.json` may break the plugin. In this case git can be instructed
+    to ignore local changes file can be safely removed without impacting the remote.
+
+    git update-index --assume-unchanged .luarc.json
+    rm .luarc.json
 
 
 REQUIREMENTS                          *lazydev.nvim-lazydev.nvim-requirements*


### PR DESCRIPTION
## Description

`.luarc.json` broke the lazydev and I have not enough experience to configure the file properly. I was looking for a way I can stay with this plugin in a project using a `.luarc.json` file.

## Related Issue(s)

none

## Screenshots

