### PR TITLE
docs: remove unnecessary `and true` in example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Examples:
     -- always enable unless `vim.g.lazydev_enabled = false`
     -- This is the default
     enabled = function(root_dir)
-      return vim.g.lazydev_enabled == nil and true or vim.g.lazydev_enabled
+      return vim.g.lazydev_enabled == nil or vim.g.lazydev_enabled
     end,
     -- disable when a .luarc.json file is found
     enabled = function(root_dir)
@@ -138,7 +138,7 @@ local defaults = {
   },
   ---@type boolean|(fun(root:string):boolean?)
   enabled = function(root_dir)
-      return vim.g.lazydev_enabled == nil and true or vim.g.lazydev_enabled
+      return vim.g.lazydev_enabled == nil or vim.g.lazydev_enabled
   end,
 }
 ```


### PR DESCRIPTION
## Description

Just a small cleanup in example config. `and true` does nothing unless I'm missing something here.

## Related Issue(s)

None

## Screenshots

None
