### PR TITLE
fix(lsp): update client.notify to client:notify for v0.11

### DIFF
--- a/lua/lazydev/config.lua
+++ b/lua/lazydev/config.lua
@@ -45,6 +45,7 @@ function M.is_enabled(root)
 end
 
 M.have_0_10 = vim.fn.has("nvim-0.10") == 1
+M.have_0_11 = vim.fn.has("nvim-0.11") == 1
 M.lua_root = true
 
 ---@param opts? lazydev.Config

--- a/lua/lazydev/lsp.lua
+++ b/lua/lazydev/lsp.lua
@@ -1,3 +1,4 @@
+local Config = require("lazydev.config")
 local Workspace = require("lazydev.workspace")
 
 local M = {}
@@ -87,9 +88,15 @@ end
 ---@param client vim.lsp.Client
 function M.update(client)
   M.assert(client)
-  client.notify("workspace/didChangeConfiguration", {
-    settings = { Lua = {} },
-  })
+  if Config.have_0_11 then
+    client:notify("workspace/didChangeConfiguration", {
+      settings = { Lua = {} },
+    })
+  else
+    client.notify("workspace/didChangeConfiguration", {
+      settings = { Lua = {} },
+    })
+  end
 end
 
 return M


### PR DESCRIPTION
## Description

Removes call to deprecated function (client.notify) and replaces it with client:notify


Performing changes requested in https://github.com/folke/lazydev.nvim/pull/98