### PR TITLE
fix: use `client:notify()` instead of deprecated `client.notify`

### DIFF
--- a/lua/lazydev/lsp.lua
+++ b/lua/lazydev/lsp.lua
@@ -87,7 +87,7 @@ end
 ---@param client vim.lsp.Client
 function M.update(client)
   M.assert(client)
-  client.notify("workspace/didChangeConfiguration", {
+  client:notify("workspace/didChangeConfiguration", {
     settings = { Lua = {} },
   })
 end


### PR DESCRIPTION
## Description

Updates the plugin to use `client:notify()` since `client.notify` was deprecated in 0.11 and causes a warning.

