### PR TITLE
fix(lsp): client.notify deprecated

### DIFF
--- a/lua/lazydev/lsp.lua
+++ b/lua/lazydev/lsp.lua
@@ -87,7 +87,7 @@ end
 ---@param client vim.lsp.Client
 function M.update(client)
   M.assert(client)
-  client.notify("workspace/didChangeConfiguration", {
+  client:notify("workspace/didChangeConfiguration", {
     settings = { Lua = {} },
   })
 end


### PR DESCRIPTION
## Description

client.notify() is deprecated and will be removed in neovim 0.13. This is currently causing a warning in neovim 0.12. This corrects its usage to client:notify().
