### PR TITLE
fix(chore): updated the deprecated `client.notify` to `client:notify`

### DIFF
--- a/lua/lazydev/lsp.lua
+++ b/lua/lazydev/lsp.lua
@@ -87,7 +87,7 @@ end
 ---@param client vim.lsp.Client
 function M.update(client)
   M.assert(client)
-  client.notify("workspace/didChangeConfiguration", {
+  client:notify("workspace/didChangeConfiguration", {
     settings = { Lua = {} },
   })
 end


### PR DESCRIPTION
## Description
While opening any lua files I started seeing the below mentioned error message.

```txt
- ⚠️ WARNING client.notify is deprecated. Feature will be removed in Nvim 0.13
  - ADVICE:
    - use client:notify instead.
```

So, I followed the trace log and then made the update as suggested by the log.

> It was relatively small enough change so, I did not bother with opening an issue first.
> I don't know much about neovim plugins and this is my first ever contribution since, I felt annoyed by the warning and felt like many were going through the same.

# System and tools info:
**Neovim**: NVIM v0.12.0-dev-333+g50c200fcd4
**OS**: 6.14.5-arch1-1
**lazydev**: 2367a6c

# Update
My bad I did search for the issues, in the issues pannel but didnot search for similar prs.
So, closing in favor of.
 #106