### PR TITLE
fix(lsp): replace deprecated client.notify with client:notify

### DIFF
--- a/lua/lazydev/lsp.lua
+++ b/lua/lazydev/lsp.lua
@@ -87,7 +87,7 @@ end
 ---@param client vim.lsp.Client
 function M.update(client)
   M.assert(client)
-  client.notify("workspace/didChangeConfiguration", {
+  client:notify("workspace/didChangeConfiguration", {
     settings = { Lua = {} },
   })
 end


### PR DESCRIPTION
This PR replaces the deprecated call to client.notify(...) with the correct method-style call client:notify(...) as recommended in Neovim's deprecation notice.

📋 Context
Neovim has deprecated client.notify in favor of client:notify, and the current implementation triggers the following warning:

pgsql
Copy
Edit
client.notify is deprecated. Feature will be removed in Nvim 0.13 This change ensures forward compatibility with Neovim 0.13+ and removes the deprecation warning shown in :checkhealth.

✅ Changes
Updated usage of client.notify(...) to client:notify(...) in:

lua/lazydev/lsp.lua

🧪 Testing
Confirmed that LSP features still work as expected

No deprecation warning is shown on startup or in :checkhealth

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

