### PR TITLE
fix(workspace): extend ignoreDir

### DIFF
--- a/lua/lazydev/workspace.lua
+++ b/lua/lazydev/workspace.lua
@@ -172,6 +172,7 @@ function M:update()
     end
   end
 
+  local defaultIgnoreDir = settings.Lua and settings.Lua.workspace and settings.Lua.workspace.ignoreDir or {}
   settings = vim.tbl_deep_extend("force", settings, {
     Lua = {
       runtime = {
@@ -182,7 +183,7 @@ function M:update()
       workspace = {
         checkThirdParty = false,
         library = library,
-        ignoreDir = Config.lua_root and { "/lua" } or nil,
+        ignoreDir = Config.lua_root and { "/lua", unpack(defaultIgnoreDir) } or defaultIgnoreDir,
       },
     },
   })


### PR DESCRIPTION
## Context

Because of how `vim.tbl_deep_extend` works, the `workspace.ignoreDir` setting is overwritten by `lazyDev`.

## Change

I propose keeping the existing `ignoreDir` setting set by the user (if any) and extending it.