### PR TITLE
fix(workspace): recursively add library tables

### DIFF
--- a/lua/lazydev/workspace.lua
+++ b/lua/lazydev/workspace.lua
@@ -203,14 +203,30 @@ function M:debug(opts)
     Util.warn("Found `.luarc.json` in workspace. This may break **lazydev.nvim**\n- `" .. rc .. "`")
   end
   opts = opts or {}
-  local root = M.is_special(self.root) and "[" .. self.root .. "]" or vim.fn.fnamemodify(self.root, ":~")
+  local root = self.is_special(self.root) and "[" .. self.root .. "]" or vim.fn.fnamemodify(self.root, ":~")
   local lines = { "## " .. root }
   ---@type string[]
   local library = vim.tbl_get(self.settings, "Lua", "workspace", "library") or {}
+
+  ---@param value string[]|string
+  ---@param mods string
+  local function fnamemodify(value, mods)
+    if type(value) == "table" then
+      for _, val in ipairs(value) do
+        fnamemodify(val, mods)
+      end
+
+      return
+    end
+
+    value = vim.fn.fnamemodify(value, mods)
+
+    local plugin = Pkg.get_plugin_name(value .. "/")
+    table.insert(lines, "- " .. (plugin and "**" .. plugin .. "** " or "") .. ("`" .. value .. "`"))
+  end
+
   for _, lib in ipairs(library) do
-    lib = vim.fn.fnamemodify(lib, ":~")
-    local plugin = Pkg.get_plugin_name(lib .. "/")
-    table.insert(lines, "- " .. (plugin and "**" .. plugin .. "** " or "") .. ("`" .. lib .. "`"))
+    fnamemodify(lib, ":~")
   end
   if opts.details then
     lines[#lines + 1] = "```lua"


### PR DESCRIPTION
## Description

I've noticed this plugin crash when setting the following `lua_ls`:

```lua
client.settings.Lua.workspace.library = { vim.api.nvim_get_runtime_file('', true), ... }
```

`vim.api.nvim_get_runtime_file()` returns a `string[]` type, and yet it does work (at least in my config).

This would break LazyDev, even though this is explicitly suggested as an option in `nvim-lspconfig`: https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#lua_ls

> I feel you might find this one as a stretch, but I feel this might be of use

## Related Issue(s)

None I could find, whether open, closed or merged (if PR)

## Screenshots

 If trying to run `:LazyDev debug` in a LuaLS environment, this happens:

 ![LazyDev_Error](https://github.com/user-attachments/assets/c937399c-0302-4302-8e96-18fef6a4606b)

After this patch:

![LazyDev_Success](https://github.com/user-attachments/assets/91d1fa3a-328a-4411-8394-34000377bcab)


