### PR TITLE
fix(docs): updated to `DrKJeff16/wezterm-types`

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Examples:
       -- Only load the lazyvim library when the `LazyVim` global is found
       { path = "LazyVim", words = { "LazyVim" } },
       -- Load the wezterm types when the `wezterm` module is required
-      -- Needs `justinsgithub/wezterm-types` to be installed
+      -- Needs `DrKJeff16/wezterm-types` to be installed
       { path = "wezterm-types", mods = { "wezterm" } },
       -- Load the xmake types when opening file named `xmake.lua`
       -- Needs `LelouchHe/xmake-luals-addon` to be installed


### PR DESCRIPTION
## Description

@justinsgithub has transferred the ownership of the repository to me (https://github.com/DrKJeff16/wezterm-types/discussions/46)

In addition, on the repo we have included instructions for `lazydev.nvim` too.

## Related Issue(s)
_None that exists_

## Screenshots

<img width="1238" height="787" alt="Changes" src="https://github.com/user-attachments/assets/8d7badc0-527a-4a95-a2db-0becd6ad487c" />

