### PR TITLE
fix(lspconfig): add check for lsp.is_enabled

### DIFF
--- a/lua/lazydev/integrations/lspconfig.lua
+++ b/lua/lazydev/integrations/lspconfig.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 function M.setup()
-  if vim.fn.has("nvim-0.11.2") == 0 then
+  if vim.fn.has("nvim-0.11.2") == 0 or not vim.lsp.is_enabled then
     return
   end
   for _, server in ipairs(require("lazydev.lsp").supported_clients) do


### PR DESCRIPTION
## Description

Some users are on nightlies from sources that aren't consistently updated, such as Ubuntu's [Neovim PPA](https://launchpad.net/~neovim-ppa).

The current check for >=`0.11.2` prevents them from using lazydev.nvim unless they change where they source their build from.

Adding a check for the `vim.lsp.is_enabled` method causing the failure prevents this and ensures continuity of use for these users.

## Related Issue(s)
- Fixes #121 #122 

## Screenshots

<img width="604" height="497" alt="image" src="https://github.com/user-attachments/assets/275c145b-7bcd-4659-a9ce-f11068a3b54c" />

