### PR TITLE
feat(blink): add `textEdit` to completion items

### DIFF
--- a/lua/lazydev/integrations/blink.lua
+++ b/lua/lazydev/integrations/blink.lua
@@ -50,6 +50,19 @@ function M:get_completions(ctx, callback)
         kind = vim.lsp.protocol.CompletionItemKind.Module,
         insertTextFormat = vim.lsp.protocol.InsertTextFormat.PlainText,
         insertText = last,
+        textEdit = {
+          newText = last,
+          range = {
+            start = {
+              line = ctx.cursor[1] - 1,
+              character = ctx.bounds.start_col - 1,
+            },
+            ["end"] = {
+              line = ctx.cursor[1] - 1,
+              character = ctx.cursor[2],
+            },
+          },
+        },
       }
     local item = items[modname]
     -- item.label = "test + " .. item.label


### PR DESCRIPTION
This avoids the need for guesswork from the completion engine.

Historically, issue #103 was never resolved, which led to a hack in `blink.cmp` to work around it:
https://github.com/saghen/blink.cmp/commit/59507fd789564365301a9182b1c91982b7a39607
