### PR TITLE
fix(util): normalized path should always end in /

### DIFF
--- a/lua/lazydev/util.lua
+++ b/lua/lazydev/util.lua
@@ -35,6 +35,9 @@ function M.norm(path)
   if path:sub(2, 2) == ":" then
     path = path:sub(1, 1):upper() .. path:sub(2)
   end
+
+  path = path:sub(-1) ~= "/" and path .. "/" or path
+
   return path
 end
 


### PR DESCRIPTION
## Description

Otherwise we won't always match an existing lsp client and will end up spawning duplicate language servers.

Found while digging into
https://github.com/neovim/neovim/issues/36464

## Screenshots

before:

<img width="2056" height="1286" alt="Screenshot 2025-11-06 at 01 34 17" src="https://github.com/user-attachments/assets/5e41fb0b-4d80-4682-be48-c5f41fd41630" />


after:

<img width="2056" height="1286" alt="Screenshot 2025-11-06 at 01 34 39" src="https://github.com/user-attachments/assets/755c0a6e-80d9-47d8-b4e0-33be61b98d06" />

