### PR TITLE
feat: provide full support for emmylua-analyzer

### DIFF
--- a/lua/lazydev/lsp.lua
+++ b/lua/lazydev/lsp.lua
@@ -63,7 +63,7 @@ function M.on_workspace_configuration(err, params, ctx, cfg)
   for _, item in ipairs(params.items) do
     if item.section then
       local settings = client.settings
-      if item.section == "Lua" then
+      if item.section == "emmylua" then
         local ws = item.scopeUri and Workspace.get(client, vim.uri_to_fname(item.scopeUri)) or Workspace.single(client)
         if ws:enabled() then
           settings = ws.settings
@@ -90,11 +90,11 @@ function M.update(client)
   M.assert(client)
   if vim.fn.has("nvim-0.11") == 1 then
     client:notify("workspace/didChangeConfiguration", {
-      settings = { Lua = {} },
+      settings = { emmylua = {} },
     })
   else
     client.notify("workspace/didChangeConfiguration", {
-      settings = { Lua = {} },
+      settings = { emmylua = {} },
     })
   end
 end

--- a/lua/lazydev/workspace.lua
+++ b/lua/lazydev/workspace.lua
@@ -178,7 +178,7 @@ function M:update()
   vim.list_extend(libs, self.library)
 
   ---@type string[]
-  local library = vim.tbl_get(settings, "Lua", "workspace", "library") or {}
+  local library = vim.tbl_get(settings, "emmylua", "workspace", "library") or {}
   for _, path in ipairs(libs) do
     if not vim.tbl_contains(library, path) then
       table.insert(library, path)
@@ -186,14 +186,15 @@ function M:update()
   end
 
   settings = vim.tbl_deep_extend("force", settings, {
-    Lua = {
+    emmylua = {
       runtime = {
         version = "LuaJIT",
-        path = Config.lua_root and { "?.lua", "?/init.lua" } or { "lua/?.lua", "lua/?/init.lua" },
-        pathStrict = true,
+        requirePattern = Config.lua_root and { "?.lua", "?/init.lua" } or { "lua/?.lua", "lua/?/init.lua" },
+      },
+      strict = {
+        requirePath = true,
       },
       workspace = {
-        checkThirdParty = false,
         library = library,
         ignoreDir = Config.lua_root and { "/lua" } or nil,
       },
@@ -219,7 +220,7 @@ function M:debug(opts)
   local root = M.is_special(self.root) and "[" .. self.root .. "]" or vim.fn.fnamemodify(self.root, ":~")
   local lines = { "## " .. root }
   ---@type string[]
-  local library = vim.tbl_get(self.settings, "Lua", "workspace", "library") or {}
+  local library = vim.tbl_get(self.settings, "emmylua", "workspace", "library") or {}
   for _, lib in ipairs(library) do
     lib = vim.fn.fnamemodify(lib, ":~")
     local plugin = Pkg.get_plugin_name(lib .. "/")


### PR DESCRIPTION
## Description

The configuration of `emmylua-analyzer` is apparently to some extent backwards-compatible with `lua-language-server`. However, the incompatibility ends as soon as you use its own configuration paths: If the language server settings contain a `emmylua` section, the `Lua` section is ignored. Hence, I would like to have full support for `emmylua-analyzer` in lazydev.

The current state of the PR serves as a PoC to show where and how the plugin would need to be adapted.

## Related Issue(s)

## Screenshots
